### PR TITLE
feat(search): 検索機能を追加し、検索結果の表示スタイルを更新

### DIFF
--- a/src/app/(public)/page.module.css
+++ b/src/app/(public)/page.module.css
@@ -17,3 +17,19 @@
     gap: 2rem;
   }
 }
+
+.searchResults {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  color: #111827;
+}
+
+.noResults {
+  text-align: center;
+  padding: 2rem;
+  color: #4b5563;
+  background-color: #f9fafb;
+  border-radius: 0.5rem;
+  font-size: 1.1rem;
+}

--- a/src/app/(public)/posts/fetcher.ts
+++ b/src/app/(public)/posts/fetcher.ts
@@ -1,4 +1,4 @@
-import { GET_POSTS, GET_POST } from '@/app/graphql/posts/queries';
+import { GET_POSTS, GET_POST, SEARCH_POSTS } from '@/app/graphql/posts/queries';
 import { apolloClient } from '@/app/graphql/apollo-client';
 import { Post, PostsResponse } from '@/app/types';
 
@@ -16,4 +16,12 @@ export async function getPost(id: string) {
     variables: { id }
   });
   return { json: () => Promise.resolve(data.post as Post) };
+}
+
+export async function searchPosts(title: string, page = 1, perPage = 15) {
+  const { data } = await apolloClient.query({
+    query: SEARCH_POSTS,
+    variables: { title, page, perPage }
+  });
+  return { json: () => Promise.resolve(data.searchPosts as PostsResponse) };
 }

--- a/src/app/graphql/posts/queries.ts
+++ b/src/app/graphql/posts/queries.ts
@@ -23,6 +23,29 @@ export const GET_POSTS = gql`
   }
 `;
 
+export const SEARCH_POSTS = gql`
+  query SearchPosts($title: String!, $page: Int, $perPage: Int) {
+    searchPosts(title: $title, page: $page, perPage: $perPage) {
+      posts {
+        id
+        userId
+        title
+        content
+        thumbnailUrl
+        published
+        createdAt
+        updatedAt
+      }
+      pagination {
+        totalCount
+        limitValue
+        totalPages
+        currentPage
+      }
+    }
+  }
+`;
+
 export const GET_POST = gql`
   query GetPost($id: ID!) {
     post(id: $id) {

--- a/src/components/layouts/PublicHeader.module.css
+++ b/src/components/layouts/PublicHeader.module.css
@@ -19,11 +19,6 @@
   .container {
     padding: 0 32px;
   }
-
-  .searchBox {
-    position: relative;
-    display: block !important;
-  }
 }
 
 .content {
@@ -31,10 +26,6 @@
   justify-content: space-between;
   align-items: center;
   height: 64px;
-}
-
-.searchBox {
-  display: none;
 }
 
 .logo {
@@ -61,50 +52,4 @@
   display: flex;
   align-items: center;
   gap: 16px;
-}
-
-.searchInput {
-  width: 256px;
-  padding: 8px 16px;
-  border: 1px solid #d1d5db;
-  border-radius: 6px;
-  font-size: 14px;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-}
-
-.searchInput:focus {
-  outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.5);
-}
-
-.loginButton {
-  padding: 8px 16px;
-  font-size: 14px;
-  font-weight: 500;
-  color: #374151;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-}
-
-.loginButton:hover {
-  color: #111827;
-}
-
-.registerButton {
-  padding: 8px 16px;
-  font-size: 14px;
-  font-weight: 500;
-  color: #ffffff;
-  background-color: #2563eb;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-}
-
-.registerButton:hover {
-  background-color: #1d4ed8;
 }

--- a/src/components/layouts/PublicHeader.tsx
+++ b/src/components/layouts/PublicHeader.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 import styles from './PublicHeader.module.css'
 import { Button } from '../ui/Button/Button'
 import Link from 'next/link'
+import SearchBox from '../search/SearchBox'
 
 export default function PublicHeader() {
   return (
@@ -22,13 +23,7 @@ export default function PublicHeader() {
           </div>
 
           <div className={styles.navigation}>
-            <div className={styles.searchBox}>
-              <input
-                type="text"
-                placeholder="記事を検索..."
-                className={styles.searchInput}
-              />
-            </div>
+            <SearchBox />
 
             <Button type="neutral">ログイン</Button>
             <Button>登録</Button>

--- a/src/components/search/SearchBox.module.css
+++ b/src/components/search/SearchBox.module.css
@@ -1,0 +1,47 @@
+.searchContainer {
+  position: relative;
+  width: 256px;
+}
+
+.searchBox {
+  position: relative;
+  width: 100%;
+}
+
+.searchInput {
+  width: 100%;
+  padding: 8px 16px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.2s ease;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.5);
+}
+
+.searchIcon {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #6b7280;
+}
+
+/* モバイル表示対応 */
+@media (max-width: 768px) {
+  .searchContainer {
+    display: none;
+  }
+}
+
+@media (min-width: 768px) {
+  .searchContainer {
+    display: block;
+  }
+}

--- a/src/components/search/SearchBox.tsx
+++ b/src/components/search/SearchBox.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import styles from './SearchBox.module.css';
+
+export default function SearchBox() {
+  const searchParams = useSearchParams();
+  const [search, setSearch] = useState(searchParams.get('title') || '');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  useEffect(() => {
+    if (debouncedSearch.trim()) {
+      router.push(`/?title=${debouncedSearch.trim()}`);
+    } else if (debouncedSearch === '') {
+      router.push('/');
+    }
+  }, [debouncedSearch, router]);
+
+  return (
+    <div className={styles.searchContainer}>
+      <div className={styles.searchBox}>
+        <input
+          type="text"
+          placeholder="記事を検索..."
+          className={styles.searchInput}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <div className={styles.searchIcon}>
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+            <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/search/SearchBox.tsx
+++ b/src/components/search/SearchBox.tsx
@@ -7,7 +7,7 @@ import styles from './SearchBox.module.css';
 export default function SearchBox() {
   const searchParams = useSearchParams();
   const [search, setSearch] = useState(searchParams.get('title') || '');
-  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState(search);
   const router = useRouter();
 
   useEffect(() => {


### PR DESCRIPTION
## 概要

ヘッダーの検索ボックスを機能させ、タイトルによる記事検索をエンドツーエンドで実装しました。

## 変更内容

### 新規追加

- **`SearchBox` コンポーネント** (`src/components/search/SearchBox.tsx`)
  - 入力から 500ms のデバウンス後に `?title=` クエリパラメータで遷移
  - ページ再訪時は URL の `title` パラメータを初期値として反映
  - モバイル（< 768px）では非表示
- **`SEARCH_POSTS` GraphQL クエリ** — タイトルでの部分一致検索。ページネーション対応
- **`searchPosts` fetcher** — `SEARCH_POSTS` クエリを呼び出す非同期関数

### 変更

- **トップページ** (`page.tsx`) — `title` パラメータがあれば `searchPosts`、なければ `getPosts` を呼び分け。検索中は結果見出し「「{キーワード}」の検索結果」を表示し、0 件時は案内メッセージを表示
- **`PublicHeader`** — ハードコードされた `<input>` を `<SearchBox />` コンポーネントに置き換え、関連 CSS を削除

## スクリーンショット

<img width="1414" alt="image" src="https://github.com/user-attachments/assets/89cee3b1-44ee-46c1-9562-6b42e4409501"/>