### PR TITLE
feat(posts): StatusBadgeコンポーネント、スタイル、テストを追加

### DIFF
--- a/src/components/features/posts/StatusBadge.module.css
+++ b/src/components/features/posts/StatusBadge.module.css
@@ -1,0 +1,21 @@
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.badge__draft {
+  background-color: rgb(238, 252, 227);
+  color: rgb(66, 129, 14);
+  border: 1px solid rgb(66, 129, 14);
+}
+
+.badge__published {
+  background-color: rgb(230, 247, 255);
+  color: rgb(0, 121, 173);
+  border: 1px solid rgb(0, 121, 173);
+}

--- a/src/components/features/posts/StatusBadge.test.tsx
+++ b/src/components/features/posts/StatusBadge.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { StatusBadge } from "./StatusBadge";
+
+describe('StatusBadge', () => {
+  describe('初期表示', () => {
+    it('publishedの場合', () => {
+      render(<StatusBadge status="published" />);
+      expect(screen.getByText('公開中')).toBeInTheDocument();
+    });
+
+    it('draftの場合', () => {
+      render(<StatusBadge status="draft" />);
+      expect(screen.getByText('下書き')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/features/posts/StatusBadge.tsx
+++ b/src/components/features/posts/StatusBadge.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import React from 'react';
+import styles from './StatusBadge.module.css'
+
+interface StatusBadgeProps {
+  status: 'draft' | 'published';
+}
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  const getStatusText = (status: StatusBadgeProps['status']): string => {
+    switch (status) {
+      case 'draft':
+        return '下書き';
+      case 'published':
+        return '公開中';
+    }
+  };
+
+  return (
+    <span className={`${styles.badge} ${styles[`badge__${status}`]}`}>
+      {getStatusText(status)}
+    </span>
+  );
+}


### PR DESCRIPTION
# Design

<img width="126" alt="image" src="https://github.com/user-attachments/assets/ec764d5f-2f2d-4858-8ad7-0036c8ab0c4f" />
